### PR TITLE
Universal Tracker support + Renamed region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.gb
 *.gbc
 *.gba
+*.nds
 *.wixobj
 *.lck
 *.db3

--- a/worlds/ffta/__init__.py
+++ b/worlds/ffta/__init__.py
@@ -3,11 +3,12 @@ Archipelago World definition for Final Fantasy Tactics Advance
 """
 
 import os
-from typing import ClassVar, Dict, Any, Union, Tuple
+from typing import ClassVar, Dict, Any, Union, Tuple, Optional
 import settings
 import sys
 import logging
 from Utils import visualize_regions
+from random import Random
 
 from .client import FFTAClient
 
@@ -119,6 +120,15 @@ class FFTAWorld(World):
         self.recruit_secret = [0x03, 0x0f, 0x17, 0x20, 0x29, 0x8a, 0x8c, 0x8e,
                                0x90, 0x92, 0x94, 0x96, 0x98, 0x9a, 0x9c, 0x9e]
         self.special_units = [0x04, 0x09, 0x0a, 0x0c, 0x0d, 0x5a, 0x5e]
+
+        self.seed = getattr(multiworld, "re_gen_passthrough", {}).get("Final Fantasy Tactics Advance", self.random.getrandbits(64))
+        self.random = Random(self.seed)
+
+    def interpret_slot_data(self, slot_data: Dict[str, Any]) -> Optional[int]:
+        seed = slot_data.get("universal_tracker_seed")
+        if seed is None:
+            print("This game was generated before Universal Tracker support")
+        return seed
 
     def get_filler_item_name(self) -> str:
         filler = ["Potion", "Hi-Potion", "X-Potion", "Ether", "Elixir", "Antidote",
@@ -407,6 +417,8 @@ class FFTAWorld(World):
             "progressive_shop_tiers",
             "law_cards"
         )
+
+        slot_data["universal_tracker_seed"] = self.seed
 
         return slot_data
 

--- a/worlds/ffta/client.py
+++ b/worlds/ffta/client.py
@@ -3,6 +3,8 @@ import time
 import logging
 import sys
 import struct
+import asyncio
+import Utils
 
 from .options import FinalMission, JobUnlockReq
 
@@ -11,18 +13,86 @@ import worlds._bizhawk as bizhawk
 from worlds._bizhawk.client import BizHawkClient
 from .items import JobUnlockDict
 from .locations import (MissionGroups, DispatchMissionGroups, bitflags)
-from worlds.LauncherComponents import SuffixIdentifier, components
+from worlds.LauncherComponents import SuffixIdentifier, components, Component, Type, launch_subprocess
 from .fftautils import xorshift32
+
 
 if TYPE_CHECKING:
     from worlds._bizhawk.context import BizHawkClientContext
 else:
     BizHawkClientContext = object
 
+clientRegistered = False
 for component in components:
-    if component.script_name == "BizHawkClient":
+    if component.script_name == "BizHawkClientUniversalTracker":
         component.file_identifier = SuffixIdentifier(*(*component.file_identifier.suffixes, ".apffta"))
+        clientRegistered = True
         break
+
+if not clientRegistered:
+    def my_launch(*launch_args) -> None:
+        from CommonClient import get_base_parser, server_loop, logger, gui_enabled
+        from worlds._bizhawk.context import BizHawkClientContext, BizHawkClientCommandProcessor, _patch_and_run_game, _game_watcher
+
+        tracker_loaded = False
+        try:
+            from worlds.tracker.TrackerClient import TrackerGameContext as SuperContext
+            from worlds.tracker.TrackerClient import TrackerCommandProcessor as SuperCommandProcessor
+            tracker_loaded = True
+        except ModuleNotFoundError:
+            from CommonClient import CommonContext as SuperContext
+            from CommonClient import ClientCommandProcessor as SuperCommandProcessor
+
+        async def main():
+            parser = get_base_parser()
+            parser.add_argument("patch_file", default="", type=str, nargs="?", help="Path to an Archipelago patch file")
+            args = parser.parse_args(launch_args)
+
+            class MyClientCommandProcessor(BizHawkClientCommandProcessor, SuperCommandProcessor):
+                pass
+
+            class MyClientContext(BizHawkClientContext, SuperContext):
+                command_processor = MyClientCommandProcessor
+
+                def on_package(self, cmd, args):
+                    super().on_package(cmd, args)
+                    if tracker_loaded:
+                        SuperContext.on_package(self, cmd, args)
+
+            ctx = MyClientContext(args.connect, args.password)
+            ctx.server_task = asyncio.create_task(server_loop(ctx), name="ServerLoop")
+            if tracker_loaded:
+                ctx.run_generator()
+            if gui_enabled:
+                ctx.run_gui()
+            ctx.run_cli()
+
+            if args.patch_file != "":
+                Utils.async_start(_patch_and_run_game(args.patch_file))
+
+            watcher_task = asyncio.create_task(_game_watcher(ctx), name="GameWatcher")
+
+            try:
+                await watcher_task
+            except Exception as e:
+                logger.exception(e)
+
+            await ctx.exit_event.wait()
+            await ctx.shutdown()
+
+        Utils.init_logging("BizHawkClientUniversalTracker", exception_logger="Client")
+        import colorama
+        colorama.init()
+        asyncio.run(main())
+        colorama.deinit()
+
+    def my_launch_client(*args) -> None:
+        launch_subprocess(my_launch, name="BizHawkClientUniversalTracker", args=args)
+
+    component = Component("BizHawk Client + Universal Tracker", "BizHawkClientUniversalTracker",
+                          component_type=Type.CLIENT, func=my_launch_client,
+                          file_identifier=SuffixIdentifier(".apffta"))
+    components.append(component)
 
 
 class FFTAClient(BizHawkClient):

--- a/worlds/ffta/regions.py
+++ b/worlds/ffta/regions.py
@@ -425,7 +425,8 @@ def create_regions(world, player) -> None:
             # Splitting gates into paths
             path = valid_gates[i+1::world.options.gate_paths.value]
             path_lengths[i] = len(path)
-
+            for gate in path:
+                gate.name += f" Path {i+1}"
             gate_1.connect(path[0], path[0].name)
             for x in range(1, len(path)):
                 path[x - 1].connect(path[x], path[x].name)

--- a/worlds/ffta/rules.py
+++ b/worlds/ffta/rules.py
@@ -77,37 +77,38 @@ def set_rules(world) -> None:
     gate_items = [(MissionUnlockItems[i].itemName,
                    MissionUnlockItems[i+1].itemName) for i in range(0, len(MissionUnlockItems), 2)]
 
+    gates = world.multiworld.get_regions(world.player)
+    dispatch_gates = [x.name for x in gates if x.name.startswith("Dispatch")][1:]
+    gates = [x.name for x in gates if x.name.startswith("Gate")][1:]
+
     if world.options.progressive_gates.value == 1:
         sphere = 0
-        for i in range(0, num_gates):
+        for i, gate in enumerate(gates):
             path = i % world.options.gate_paths.value
             if path == 0:
                 sphere += 1
             if world.options.gate_items.value == 1:
-                add_rule(world.multiworld.get_entrance(f"Gate {i+2}", world.player),
+                add_rule(world.multiworld.get_entrance(gate, world.player),
                          rule_generator_progressive(world, f"Progressive Path {path+1}", sphere * 2))
             else:
-                add_rule(world.multiworld.get_entrance(f"Gate {i+2}", world.player),
+                add_rule(world.multiworld.get_entrance(gate, world.player),
                          rule_generator_progressive(world, f"Progressive Path {path+1}", sphere))
 
-            if world.options.gate_items.value == 2 and i < num_gates - (world.options.gate_paths.value - 1) \
-                    and world.options.dispatch.value > 0:
-                add_rule(world.multiworld.get_entrance(f"Dispatch Gate {i+2}", world.player),
-                         rule_generator_progressive(world, "Progressive Dispatch", (i+1)))
-
+        for i, dispatch_gate in enumerate(dispatch_gates):
+            add_rule(world.multiworld.get_entrance(dispatch_gate, world.player),
+                     rule_generator_progressive(world, "Progressive Dispatch", (i+1)))
     else:
-        for i in range(0, num_gates):
+        for i, gate in enumerate(gates):
             item1 = gate_items[i][0]
             item2 = gate_items[i][1]
 
-            add_rule(world.multiworld.get_entrance(f"Gate {i+2}", world.player),
+            add_rule(world.multiworld.get_entrance(gate, world.player),
                      rule_generator(world, item1))
 
             if world.options.gate_items.value == 1:
-                add_rule(world.multiworld.get_entrance(f"Gate {i+2}", world.player),
+                add_rule(world.multiworld.get_entrance(gate, world.player),
                          rule_generator(world, item2))
 
-            elif world.options.gate_items.value == 2 and i < num_gates - (world.options.gate_paths.value - 1)\
-                    and world.options.dispatch.value > 0:
-                add_rule(world.multiworld.get_entrance(f"Dispatch Gate {i+2}", world.player),
-                         rule_generator(world, item2))
+        for i, dispatch_gate in enumerate(dispatch_gates):
+            add_rule(world.multiworld.get_entrance(dispatch_gate, world.player),
+                     rule_generator(world, item2))


### PR DESCRIPTION
## What is this fixing or adding?
Added support for Universal Tracker.
Added path to region names. Enable _include_region_name_ for Universal Tracker in host.yaml to see them in the tracker.

## How was this tested?
Generated a few games. The logic shouldn't have changed.