### PR TITLE
Pulled UT client into separate apworld

### DIFF
--- a/worlds/ffta/client.py
+++ b/worlds/ffta/client.py
@@ -22,77 +22,18 @@ if TYPE_CHECKING:
 else:
     BizHawkClientContext = object
 
-clientRegistered = False
+UT_found = False
+bizhawk_component = None
 for component in components:
     if component.script_name == "BizHawkClientUniversalTracker":
         component.file_identifier = SuffixIdentifier(*(*component.file_identifier.suffixes, ".apffta"))
-        clientRegistered = True
+        UT_found = True
         break
+    elif component.script_name == "BizHawkClient":
+        bizhawk_component = component
 
-if not clientRegistered:
-    def my_launch(*launch_args) -> None:
-        from CommonClient import get_base_parser, server_loop, logger, gui_enabled
-        from worlds._bizhawk.context import BizHawkClientContext, BizHawkClientCommandProcessor, _patch_and_run_game, _game_watcher
-
-        tracker_loaded = False
-        try:
-            from worlds.tracker.TrackerClient import TrackerGameContext as SuperContext
-            from worlds.tracker.TrackerClient import TrackerCommandProcessor as SuperCommandProcessor
-            tracker_loaded = True
-        except ModuleNotFoundError:
-            from CommonClient import CommonContext as SuperContext
-            from CommonClient import ClientCommandProcessor as SuperCommandProcessor
-
-        async def main():
-            parser = get_base_parser()
-            parser.add_argument("patch_file", default="", type=str, nargs="?", help="Path to an Archipelago patch file")
-            args = parser.parse_args(launch_args)
-
-            class MyClientCommandProcessor(BizHawkClientCommandProcessor, SuperCommandProcessor):
-                pass
-
-            class MyClientContext(BizHawkClientContext, SuperContext):
-                command_processor = MyClientCommandProcessor
-
-                def on_package(self, cmd, args):
-                    super().on_package(cmd, args)
-                    if tracker_loaded:
-                        SuperContext.on_package(self, cmd, args)
-
-            ctx = MyClientContext(args.connect, args.password)
-            ctx.server_task = asyncio.create_task(server_loop(ctx), name="ServerLoop")
-            if tracker_loaded:
-                ctx.run_generator()
-            if gui_enabled:
-                ctx.run_gui()
-            ctx.run_cli()
-
-            if args.patch_file != "":
-                Utils.async_start(_patch_and_run_game(args.patch_file))
-
-            watcher_task = asyncio.create_task(_game_watcher(ctx), name="GameWatcher")
-
-            try:
-                await watcher_task
-            except Exception as e:
-                logger.exception(e)
-
-            await ctx.exit_event.wait()
-            await ctx.shutdown()
-
-        Utils.init_logging("BizHawkClientUniversalTracker", exception_logger="Client")
-        import colorama
-        colorama.init()
-        asyncio.run(main())
-        colorama.deinit()
-
-    def my_launch_client(*args) -> None:
-        launch_subprocess(my_launch, name="BizHawkClientUniversalTracker", args=args)
-
-    component = Component("BizHawk Client + Universal Tracker", "BizHawkClientUniversalTracker",
-                          component_type=Type.CLIENT, func=my_launch_client,
-                          file_identifier=SuffixIdentifier(".apffta"))
-    components.append(component)
+if not UT_found:
+    bizhawk_component.file_identifier = SuffixIdentifier(*(*bizhawk_component.file_identifier.suffixes, ".apffta"))
 
 
 class FFTAClient(BizHawkClient):


### PR DESCRIPTION
## What is this fixing or adding?
Pulls Universal Tracker client support into a separate apworld to avoid version incompatibility. Currently FFTA and FFTA2 both check if the custom bizhawk+UT client has been registered, and if not register their own version. With this update the custom client will be a separate apworld that can be updated without breaking either game (or other bizhawk games that want to use it)